### PR TITLE
Specify minimum ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+ruby '>= 2.5.7'
+
 source "https://rubygems.org"
 
 # Hello! This is where you manage which Jekyll version is used to run.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,5 +148,8 @@ DEPENDENCIES
   jekyll-sitemap
   tzinfo-data
 
+RUBY VERSION
+   ruby 2.6.3p62
+
 BUNDLED WITH
    1.17.2


### PR DESCRIPTION
Re versions and lockfiles. Here the issue is that we specify min version 2.5.7, but the lockfile has 2.6.x because that is what I am currently using so the user isn't getting what they expect...