### PR TITLE
Update search page index to fix heading typo

### DIFF
--- a/search/index.html
+++ b/search/index.html
@@ -47,7 +47,7 @@ title: Search
 
 
 {% if site.searchgov %}
-  <h1>Seach Results</h1>
+  <h1>Search Results</h1>
   <ol id="search-results"></ol>
 
   {% if site.searchgov.affiliate == "federalist-uswds-example" %}


### PR DESCRIPTION
## Description

Fix typo `Seach Result` to `Search Result` header on search page