### PR TITLE
add full URL in canonical tag

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -27,8 +27,8 @@ site, this is the place to do it.
   <meta name="twitter:description" content="{{site.description}}" />
 
   <meta property="og:type" content="article">
-  <link rel="canonical" href="{{site.baseurl}}/">
-  <meta property="og:url" content="{{site.baseurl}}/">
+  <link rel="canonical" href="{{ page.url | absolute_url }}" />
+  <meta property="og:url" content="{{ page.url | absolute_url }}" />
   <!-- Favicons
     ================================================== -->
   <!-- 128x128 -->


### PR DESCRIPTION
previously, the canonical tag on all of the pages on the site were set to / now they have full url