### PR TITLE
Enable auto-merging after approval

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -8,3 +8,7 @@ update_configs:
       - "amirbey"
     default_assignees:
       - "davemcorwin"
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "semver:minor"      


### PR DESCRIPTION
Allows Dependabot to auto-merge minor and patch version updates once the PR has been approved and passes status checks. Also added branch protections to enforce this.