### PR TITLE
streamline Docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,11 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US
 ENV LC_ALL en_US.UTF-8
 
-RUN mkdir -p /app
-
 WORKDIR /app
 
-COPY Gemfile /app
-COPY Gemfile.lock /app
-
+COPY Gemfile* ./
 RUN bundle install
 
 EXPOSE 4000
+
+CMD bundle exec jekyll serve --host 0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,12 @@
+FROM node:12 AS node
+
+WORKDIR /app
+
+COPY package.json .
+COPY package-lock.json .
+RUN npm install
+
+
 FROM ruby:2.6.6
 
 RUN apt-get update && \
@@ -13,6 +22,8 @@ WORKDIR /app
 
 COPY Gemfile* ./
 RUN bundle install
+
+COPY --from=node /app/node_modules node_modules
 
 EXPOSE 4000
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ This will create a copy of this repo in a Github repository of your choice but y
 To build but not serve the site, run `npm run build` or `bundle exec jekyll build`.
 
 #### With Docker
-    $ docker-compose run node npm install
     $ docker-compose up --build
 
 To build but not serve the site, run:

--- a/README.md
+++ b/README.md
@@ -146,8 +146,7 @@ To build but not serve the site, run `npm run build` or `bundle exec jekyll buil
 
 #### With Docker
     $ docker-compose run node npm install
-    $ docker-compose build
-    $ docker-compose up
+    $ docker-compose up --build
 
 To build but not serve the site, run:
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,7 @@ services:
       - .:/app:delegated
   ruby:
     build: .
-    working_dir: /app
     ports:
       - "4000:4000"
     volumes:
       - .:/app:delegated
-    command: bundle exec jekyll serve --host 0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,11 @@
-version: '3'
+version: "3"
 services:
-  node:
-    image: node:12
-    working_dir: /app
-    volumes:
-      - .:/app:delegated
   ruby:
     build: .
     ports:
       - "4000:4000"
     volumes:
       - .:/app:delegated
+      # to prevent the node_modules from getting hidden by the volume
+      # https://stackoverflow.com/a/32785014/358804
+      - /app/node_modules


### PR DESCRIPTION
This pull request adapts https://github.com/18F/federalist-uswds-jekyll/pull/73 to get down to a single Docker command to get up and running. To achieve this, it uses a [multi-stage build](https://docs.docker.com/develop/develop-images/multistage-build/) to install the NPM packages within containers rather than on the local filesystem, which hides the clutter from the user. Let me know what you think!