### PR TITLE
Search.gov Suggested Changes - Page Meta Information and Typeahead Functionality

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -107,19 +107,20 @@ secondary_navigation:
 # 3. Add your site/affiliate name here.
 searchgov:
 
-  # only change this if you're using a CNAME, learn more here: https://search.gov/manual/cname.html
+  # Only change this if you're using a CNAME. Learn more here: https://search.gov/manual/cname.html
   endpoint: https://search.usa.gov
 
-  # replace this with your search.gov account
+  # Replace this with your search.gov account.
   affiliate: federalist-uswds-example
 
-  # replace with your access key
+  # Replace this with your access key.
   access_key: xX1gtb2RcnLbIYkHAcB6IaTRr4ZfN-p16ofcyUebeko=
 
-  # this renders the results within the page instead of sending to user to search.gov
+  # This renders the results within the page instead of sending to user to search.gov.
   inline: true
 
-  # this allows Search.gov to present relevant type-ahead search suggestions in your website's search box.
+  # This allows Search.gov to present relevant type-ahead search suggestions in your website's search box. 
+  # If you do not want to present search suggestions, set this value to false.
   suggestions: true
 
 ##########################################################################################

--- a/_config.yml
+++ b/_config.yml
@@ -119,6 +119,9 @@ searchgov:
   # this renders the results within the page instead of sending to user to search.gov
   inline: true
 
+  # this allows Search.gov to present relevant type-ahead search suggestions in your website's search box.
+  suggestions: true
+
 ##########################################################################################
 # The values below here are more advanced and should only be
 # changed if you know what they do

--- a/_config.yml
+++ b/_config.yml
@@ -107,7 +107,7 @@ secondary_navigation:
 # 3. Add your site/affiliate name here.
 searchgov:
 
-  # You should not change this.
+  # only change this if you're using a CNAME, learn more here: https://search.gov/manual/cname.html
   endpoint: https://search.usa.gov
 
   # replace this with your search.gov account

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -16,15 +16,15 @@ site, this is the place to do it.
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- Title and meta description
     ================================================== -->
-  <title>{{site.title}}</title>
-  <meta property="og:title" content="{{site.title}}">
-  <meta name="description" content="{{site.description}}">
-  <meta property="og:description" content="{{site.description}}">
+  <title>{{ page.title | site.title }}</title>
+  <meta property="og:title" content="{{ page.title | site.title }}">
+  <meta name="description" content="{{ page.description | site.description }}">
+  <meta property="og:description" content="{{ page.description | site.description }}">
 
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@{{site.twitter}}" />
-  <meta name="twitter:title" content="{{site.title}}" />
-  <meta name="twitter:description" content="{{site.description}}" />
+  <meta name="twitter:title" content="{{ page.title | site.title }}" />
+  <meta name="twitter:description" content="{{ page.description | site.description }}" />
 
   <meta property="og:type" content="article">
   <link rel="canonical" href="{{ page.url | absolute_url }}" />

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -16,15 +16,15 @@ site, this is the place to do it.
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- Title and meta description
     ================================================== -->
-  <title>{{ page.title | site.title }}</title>
-  <meta property="og:title" content="{{ page.title | site.title }}">
-  <meta name="description" content="{{ page.description | site.description }}">
-  <meta property="og:description" content="{{ page.description | site.description }}">
+  <title>{{page.title}}</title>
+  <meta property="og:title" content="{{page.title}}">
+  <meta name="description" content="{{page.description}}">
+  <meta property="og:description" content="{{page.description}}">
 
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@{{site.twitter}}" />
-  <meta name="twitter:title" content="{{ page.title | site.title }}" />
-  <meta name="twitter:description" content="{{ page.description | site.description }}" />
+  <meta name="twitter:title" content="{{page.title}}" />
+  <meta name="twitter:description" content="{{page.description}}" />
 
   <meta property="og:type" content="article">
   <link rel="canonical" href="{{ page.url | absolute_url }}" />

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -40,5 +40,4 @@
   //]]>
   </script>
   {% endif %}  
-{% else %}
 {% endif %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -25,3 +25,20 @@
 
 {% asset uswds.min.js %}
 {% asset app.js %}
+
+{% if site.searchgov %}
+  {% if site.searchgov.suggestions == "true" %}
+  <script>
+  //<![CDATA[
+      var usasearch_config = { siteHandle:"{{ site.searchgov.affiliate }}" };
+
+      var script = document.createElement("script");
+      script.type = "text/javascript";
+      script.src = "//search.usa.gov/javascripts/remote.loader.js";
+      document.getElementsByTagName("head")[0].appendChild(script);
+
+  //]]>
+  </script>
+  {% endif %}  
+{% else %}
+{% endif %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -27,17 +27,10 @@
 {% asset app.js %}
 
 {% if site.searchgov %}
-  {% if site.searchgov.suggestions == "true" %}
-  <script>
-  //<![CDATA[
-      var usasearch_config = { siteHandle:"{{ site.searchgov.affiliate }}" };
-
-      var script = document.createElement("script");
-      script.type = "text/javascript";
-      script.src = "//search.usa.gov/javascripts/remote.loader.js";
-      document.getElementsByTagName("head")[0].appendChild(script);
-
-  //]]>
-  </script>
-  {% endif %}  
+  {% if site.searchgov.suggestions == true %}
+    <script>
+          var usasearch_config = { siteHandle: "{{ site.searchgov.affiliate }}" };
+    </script>
+    <script async src="https://search.usa.gov/javascripts/remote.loader.js" type="text/javascript"></script>
+  {% endif %}
 {% endif %}

--- a/search/index.html
+++ b/search/index.html
@@ -21,7 +21,7 @@ title: Search
       for (item in posts.web.results){
         render_result(`
           <li class="padding-bottom-5 margin-top-4 usa-prose border-bottom-05 border-base-lightest">
-            <b class="title"><a href="${posts.web.results[item]['url']}">${posts.web.results[item]['title']}</a></b>
+            <b class="title"><a href="${posts.web.results[item]['url']}">${posts.web.results[item]['title'].replace(/\uE000/g, '<span class="bg-yellow">').replace(/\uE001/g, '</span>')}</a></b>
             <div> ${posts.web.results[item]['snippet'].replace(/\uE000/g, '<span class="bg-yellow">').replace(/\uE001/g, '</span>')} </div>
           </li>
           `, true)


### PR DESCRIPTION
Hello Federalist team!

Hoping to make some changes to help sites using Search.gov, summarized below:

- Updating the page title and page description to be unique per-page, using the front matter of the page. We do _not_ recommend leaving the site.title and site.description as fallbacks for each page, as the duplicate content can impact sites negatively both on their Search.gov experience and on organic search results on Google, Bing, etc.
- Updating the description in the config.yml for the Search.gov endpoint to more clearly indicate when this would be changed
- Adding typeahead functionality to the search box, with a boolean in the config to allow users to turn it on/off, and the typeahead script itself included in the scripts.html file

Please reach out to me and @dawnpm with any questions about the changes! Appreciate your review.