### PR TITLE
Update paginate config to fix blog rendering

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -171,12 +171,6 @@ pagination:
   trail:
     before: 2
     after: 2
-  # Optional, the default file extension for generated pages (e.g html, json, xml).
-  # Internally this is set to html by default
-  extension: html
-  # Optional, the default name of the index file for generated pages (e.g. 'index.html')
-  # Without file extension
-  indexpage: "index.html"
 
 exclude:
   - package.json


### PR DESCRIPTION
Fixes https://github.com/18F/federalist-uswds-jekyll/issues/251

Not sure why, but the presence of one or both of these config values seems to break the blog pagination. Removing them will not impact anything, as the values will roll back to their defaults (which are already index and html).