### PR TITLE
Update icon mixin

### DIFF
--- a/_assets/css/overrides/_icon.scss
+++ b/_assets/css/overrides/_icon.scss
@@ -1,6 +1,6 @@
 // Override USWDS mixin to use jekyll-assets asset_url()
 
-@mixin add-color-icon($icon-object, $contrast-bg) {
+@mixin add-color-icon($icon-object, $contrast-bg: "default") {
   $filename-base: map-get($icon-object, "name");
   $svg-height: map-get($icon-object, "svg-height");
   $svg-width: map-get($icon-object, "svg-width");


### PR DESCRIPTION
Recent upstream updates to USWDS need to be reflected in starter to work properly with Jekyll asset pipeline